### PR TITLE
Fehlender Title im RSS-Feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -4,7 +4,7 @@ layout: null
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>{{ site.title | xml_escape }}</title>
+    <title>{{ site.title_left | xml_escape }} {{ site.title_right | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.url }}{{ site.baseurl }}/</link>
     <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>


### PR DESCRIPTION
Die `title` Variable existiert nicht, so dass der Title aus den Variablen `title_left` und `title_right` zusammengesetzt werden muss.